### PR TITLE
Feature/data secrets ec

### DIFF
--- a/byoda/requestauth/requestauth.py
+++ b/byoda/requestauth/requestauth.py
@@ -6,11 +6,21 @@ Helper functions for API request processing
 :license
 '''
 
+import os
+
 from uuid import UUID
 from typing import TypeVar
 from logging import Logger
 from logging import getLogger
+from urllib.parse import unquote
 from ipaddress import ip_address as IpAddress
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.x509.verification import Store
+from cryptography.x509.verification import PolicyBuilder
+from cryptography.x509.verification import VerificationError
+from cryptography.hazmat.primitives import hashes
 
 from fastapi import HTTPException
 
@@ -25,6 +35,7 @@ from byoda.datatypes import IdType
 from byoda.datatypes import AuthSource
 from byoda.datatypes import TlsStatus
 from byoda.datatypes import EntityId
+from byoda.datatypes import ServerType
 
 from byoda.secrets.secret import Secret
 from byoda.secrets.service_secret import ServiceSecret
@@ -38,6 +49,7 @@ from byoda.secrets.networkservicesca_secret import NetworkServicesCaSecret
 from byoda.servers.server import Server
 
 from byoda.util.api_client.api_client import HttpMethod
+from byoda.util.paths import Paths
 
 from byoda.exceptions import ByodaMissingAuthInfo
 
@@ -87,6 +99,7 @@ class RequestAuth:
     - account cert
     - member cert
     - service cert
+    - app cert
 
     The reverse proxy in front of the server must perform TLS handshake to
     verify that the client cert has been signed by a trusted CA and it must
@@ -108,6 +121,7 @@ class RequestAuth:
         proxy_set_header X-Client-SSL-Issuing-CA $ssl_client_i_dn;
         proxy_set_header X-Client-SSL-Subject $ssl_client_s_dn;
         proxy_set_header X-Client-SSL-Verify $ssl_client_verify;
+        proxy_set_header X-Client-SSL-Cert $ssl_client_escaped_cert;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -145,6 +159,7 @@ class RequestAuth:
         self.account_id: UUID | None = None
         self.service_id: int | None = None
         self.member_id: UUID | None = None
+        self.app_id: UUID | None = None
         self.domain: str | None = None
 
         self.id: UUID | None = None
@@ -301,6 +316,12 @@ class RequestAuth:
                 'Authenticating client cert for a service',
                 extra=self.log_extra
             )
+        elif self.id_type == IdType.APP:
+            _LOGGER.debug(
+                'Authenticating client cert for an app',
+                extra=self.log_extra
+            )
+            self.app_id = self.id
         else:
             raise HTTPException(
                 status_code=400,
@@ -361,6 +382,10 @@ class RequestAuth:
                 )
             )
 
+        self._verify_pod_client_certchain(
+            self._get_pod_account_intermediates(), 'account'
+        )
+
     def check_member_cert(self, service_id: int, network: Network) -> None:
         '''
         Checks if the M-TLS client certificate was signed the cert chain
@@ -401,6 +426,11 @@ class RequestAuth:
                 )
             ) from exc
 
+        self._verify_pod_client_certchain(
+            self._get_pod_member_intermediates(service_id),
+            f'member service {service_id}'
+        )
+
     def check_service_cert(self, network: Network) -> None:
         '''
         Checks if the MTLS client certificate was signed the cert chain
@@ -434,8 +464,17 @@ class RequestAuth:
 
             # Service CA secret gets signed by Network Services CA
             networkservices_ca_secret = NetworkServicesCaSecret(network.paths)
-            networkservices_ca_secret.review_commonname(self.issuing_ca_cn)
-        except ValueError as exc:
+            issuer_entity_id: EntityId = (
+                networkservices_ca_secret.review_commonname(self.issuing_ca_cn)
+            )
+            if (
+                issuer_entity_id.id_type != IdType.SERVICE_CA
+                or issuer_entity_id.service_id != self.service_id
+            ):
+                raise ValueError(
+                    f'Incorrect service issuer CA: {self.issuing_ca_cn}'
+                )
+        except (ValueError, PermissionError) as exc:
             raise HTTPException(
                 status_code=403,
                 detail=(
@@ -444,6 +483,11 @@ class RequestAuth:
                     f'network {network.name}'
                 )
             ) from exc
+
+        self._verify_pod_client_certchain(
+            self._get_pod_service_intermediates(self.service_id),
+            f'service {self.service_id}'
+        )
 
     def check_app_cert(self, service_id: int, network: Network) -> None:
         '''
@@ -461,21 +505,30 @@ class RequestAuth:
         # the commonname found in the certchain presented by the
         # client
         try:
-            # Member cert gets signed by Service Member CA
+            # App cert gets signed by Service Apps CA
             apps_ca_secret = AppsCaSecret(
                 service_id, network=network
             )
             entity_id: EntityId = apps_ca_secret.review_commonname(
                 self.client_cn
             )
-            self.member_id = entity_id.id
-            self.id = self.member_id
+            self.app_id = entity_id.id
+            self.id = self.app_id
             self.service_id = entity_id.service_id
 
-            # The App CA cert gets signed by the Service App CA
-            apps_ca_secret = AppsCaSecret(service_id, network=network)
-            apps_ca_secret.review_commonname(self.issuing_ca_cn)
-        except ValueError as exc:
+            # The Apps CA cert gets signed by the Service CA
+            service_ca_secret = ServiceCaSecret(service_id, network=network)
+            issuer_entity_id: EntityId = service_ca_secret.review_commonname(
+                self.issuing_ca_cn
+            )
+            if (
+                issuer_entity_id.id_type != IdType.APPS_CA
+                or issuer_entity_id.service_id != int(service_id)
+            ):
+                raise ValueError(
+                    f'Incorrect app issuer CA: {self.issuing_ca_cn}'
+                )
+        except (ValueError, PermissionError) as exc:
             raise HTTPException(
                 status_code=403,
                 detail=(
@@ -484,6 +537,229 @@ class RequestAuth:
                     f'network {network.name}'
                 )
             ) from exc
+
+        self._verify_pod_client_certchain(
+            self._get_pod_app_intermediates(service_id),
+            f'app service {service_id}'
+        )
+
+    def _verify_pod_client_certchain(
+        self, intermediates: list[x509.Certificate] | None, cert_type: str
+    ) -> None:
+        '''
+        Verify the forwarded mTLS leaf certificate against pod-local CA
+        material. Angie/Nginx only forwards the leaf cert, so the expected
+        intermediate chain must come from local pod state.
+        '''
+
+        server: Server = config.server
+        if getattr(server, 'server_type', None) != ServerType.POD:
+            return
+
+        if not self.client_cert:
+            raise HTTPException(
+                status_code=403,
+                detail='Missing forwarded TLS client certificate'
+            )
+
+        if not intermediates:
+            raise HTTPException(
+                status_code=403,
+                detail=f'Missing local CA chain for {cert_type} certificate'
+            )
+
+        network: Network = server.network
+        root_ca = getattr(network, 'root_ca', None)
+        root_cert: x509.Certificate | None = getattr(root_ca, 'cert', None)
+        if not root_cert:
+            raise HTTPException(
+                status_code=403,
+                detail='Missing local network root CA certificate'
+            )
+
+        client_cert: x509.Certificate = self._load_forwarded_client_cert()
+        self._verify_forwarded_cert_headers(client_cert)
+
+        chain: list[x509.Certificate] = self._without_root_cert(
+            intermediates, root_cert
+        )
+
+        try:
+            verifier = (
+                PolicyBuilder()
+                .store(Store([root_cert]))
+                .max_chain_depth(5)
+                .build_client_verifier()
+            )
+            verifier.verify(client_cert, chain)
+        except VerificationError as exc:
+            raise HTTPException(
+                status_code=403,
+                detail=f'Invalid TLS client certificate chain: {exc}'
+            ) from exc
+
+    def _load_forwarded_client_cert(self) -> x509.Certificate:
+        try:
+            cert_pem: bytes = unquote(self.client_cert).encode('utf-8')
+            return x509.load_pem_x509_certificate(cert_pem)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=403,
+                detail='Invalid forwarded TLS client certificate'
+            ) from exc
+
+    def _verify_forwarded_cert_headers(
+        self, cert: x509.Certificate
+    ) -> None:
+        subject_cn: str = self._certificate_common_name(cert.subject)
+        issuer_cn: str = self._certificate_common_name(cert.issuer)
+
+        if subject_cn != self.client_cn:
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    'Forwarded TLS client certificate subject does not match '
+                    'the forwarded subject DN'
+                )
+            )
+
+        if issuer_cn != self.issuing_ca_cn:
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    'Forwarded TLS client certificate issuer does not match '
+                    'the forwarded issuer DN'
+                )
+            )
+
+    @staticmethod
+    def _certificate_common_name(name: x509.Name) -> str:
+        try:
+            return name.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
+        except IndexError as exc:
+            raise HTTPException(
+                status_code=403,
+                detail='TLS client certificate is missing a common name'
+            ) from exc
+
+    def _get_pod_account_intermediates(self) -> list[x509.Certificate] | None:
+        account: Account | None = getattr(config.server, 'account', None)
+        secret: Secret | None = getattr(account, 'tls_secret', None)
+        if secret and secret.cert_chain:
+            return secret.cert_chain
+
+        return None
+
+    def _get_pod_member_intermediates(
+        self, service_id: int
+    ) -> list[x509.Certificate] | None:
+        member: Member | None = self._get_pod_membership(service_id)
+        secret: Secret | None = getattr(member, 'tls_secret', None)
+        if secret and secret.cert_chain:
+            return secret.cert_chain
+
+        return None
+
+    def _get_pod_service_intermediates(
+        self, service_id: int | None
+    ) -> list[x509.Certificate] | None:
+        if service_id is None:
+            return None
+
+        member: Member | None = self._get_pod_membership(service_id)
+        service_ca_secret: ServiceCaSecret | None = getattr(
+            member, 'service_ca_certchain', None
+        )
+        if not service_ca_secret or not service_ca_secret.cert:
+            return None
+
+        return [service_ca_secret.cert] + service_ca_secret.cert_chain
+
+    def _get_pod_app_intermediates(
+        self, service_id: int | None
+    ) -> list[x509.Certificate] | None:
+        if service_id is None:
+            return None
+
+        apps_ca_cert: x509.Certificate | None = self._get_pod_apps_ca_cert(
+            service_id
+        )
+        service_chain: list[x509.Certificate] | None = (
+            self._get_pod_service_intermediates(service_id)
+        )
+        if not apps_ca_cert or not service_chain:
+            return None
+
+        return [apps_ca_cert] + service_chain
+
+    def _get_pod_apps_ca_cert(
+        self, service_id: int
+    ) -> x509.Certificate | None:
+        member: Member | None = self._get_pod_membership(service_id)
+        service = getattr(member, 'service', None)
+        apps_ca_secret: AppsCaSecret | None = getattr(
+            service, 'apps_ca', None
+        )
+        if apps_ca_secret and apps_ca_secret.cert:
+            return apps_ca_secret.cert
+
+        return self._load_local_pod_apps_ca_cert(service_id)
+
+    def _load_local_pod_apps_ca_cert(
+        self, service_id: int
+    ) -> x509.Certificate | None:
+        server: Server = config.server
+        network: Network | None = getattr(server, 'network', None)
+        paths: Paths | None = getattr(network, 'paths', None)
+        if not paths:
+            return None
+
+        try:
+            cert_file: str = paths.get(
+                Paths.SERVICE_APPS_CA_CERT_FILE, service_id=int(service_id)
+            )
+        except (KeyError, ValueError):
+            return None
+
+        storage_driver = getattr(server, 'local_storage', None)
+        if not storage_driver:
+            storage_driver = getattr(paths, 'storage_driver', None)
+        if not storage_driver:
+            return None
+
+        dirpath, filename = storage_driver.get_full_path(
+            cert_file, create_dir=False
+        )
+        filepath: str = os.path.join(dirpath, filename)
+        if not os.path.exists(filepath):
+            return None
+
+        with open(filepath, 'rb') as file_desc:
+            certs: list[x509.Certificate] = x509.load_pem_x509_certificates(
+                file_desc.read()
+            )
+        if not certs:
+            return None
+
+        return certs[0]
+
+    @staticmethod
+    def _get_pod_membership(service_id: int) -> Member | None:
+        account: Account | None = getattr(config.server, 'account', None)
+        memberships: dict[int, Member] = (
+            getattr(account, 'memberships', None) or {}
+        )
+        return memberships.get(int(service_id))
+
+    @staticmethod
+    def _without_root_cert(
+        certs: list[x509.Certificate], root_cert: x509.Certificate
+    ) -> list[x509.Certificate]:
+        root_fingerprint: bytes = root_cert.fingerprint(hashes.SHA256())
+        return [
+            cert for cert in certs
+            if cert.fingerprint(hashes.SHA256()) != root_fingerprint
+        ]
 
     @staticmethod
     def get_commonname(dname: str) -> str:

--- a/byoda/secrets/account_data_secret.py
+++ b/byoda/secrets/account_data_secret.py
@@ -72,7 +72,7 @@ class AccountDataSecret(DataSecret):
     async def create_csr(self, account_id: UUID = None, renew: bool = False
                          ) -> CertificateSigningRequest:
         '''
-        Creates an RSA private key and X.509 CSR
+        Creates a private key and X.509 CSR
 
         :param account_id: identifier for the account to be used in the CSR
         :param renew: should any existing private key be used to

--- a/byoda/secrets/app_data_secret.py
+++ b/byoda/secrets/app_data_secret.py
@@ -92,7 +92,7 @@ class AppDataSecret(DataSecret):
     async def create_csr(self, fqdn: str, renew: bool = False
                          ) -> CertificateSigningRequest:
         '''
-        Creates an RSA private key and X.509 CSR
+        Creates a private key and X.509 CSR
 
         :param app_id: identifier for the app
         :param renew: should any existing private key be used to
@@ -103,7 +103,6 @@ class AppDataSecret(DataSecret):
         '''
 
         self.fqdn: str = fqdn
-
 
         common_name: str = AppDataSecret.create_commonname(
             self.app_id, self.service_id, self.network

--- a/byoda/secrets/data_secret.py
+++ b/byoda/secrets/data_secret.py
@@ -6,6 +6,10 @@ Cert manipulation
 :license    : GPLv3
 '''
 
+import base64
+import binascii
+import json
+import os
 import struct
 
 from copy import copy
@@ -19,13 +23,14 @@ from datetime import datetime
 from datetime import timedelta
 
 from cryptography import x509
+from cryptography.exceptions import InvalidTag
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric import utils
-from cryptography.hazmat.primitives.asymmetric import padding
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 # Imports that enable code to import from this module
 from cryptography.exceptions import InvalidSignature        # noqa: F401
@@ -43,9 +48,17 @@ Server = TypeVar('Server')
 
 _LOGGER: Logger = getLogger(__name__)
 
+_KEY_ENVELOPE_MAGIC: bytes = b'BYODA-DATA-KEY-v1\n'
+_KEY_ENVELOPE_ALGORITHM: str = 'ECDH-P256-HKDF-SHA256-AESGCM'
+_KEY_ENVELOPE_CURVE: str = 'secp256r1'
+_KEY_ENVELOPE_INFO: bytes = b'byoda data secret protected shared key v1'
+_KEY_ENVELOPE_SALT_LENGTH: int = 32
+_KEY_ENVELOPE_NONCE_LENGTH: int = 12
+_KEY_ENVELOPE_KEY_LENGTH: int = 32
+
 # This is not a limit to the data getting signed or verified, but
 # a limit to the amount of data fed to the hasher at each iteration
-_RSA_SIGN_MAX_MESSAGE_LENGTH = 1024
+_SIGN_MAX_MESSAGE_LENGTH = 1024
 
 
 class DataSecret(Secret):
@@ -57,7 +70,7 @@ class DataSecret(Secret):
     Properties:
     - cert                 : instance of cryptography.x509
     - key                  : instance of
-                             cryptography.hazmat.primitives.asymmetric.rsa
+                             cryptography.hazmat.primitives.asymmetric.ec
     - password             : string protecting the private key
     - shared_key           : unprotected shared secret used by Fernet
     - protected_shared_key : protected shared secret used by Fernet
@@ -72,15 +85,12 @@ class DataSecret(Secret):
     RENEW_WANTED: datetime = datetime.now(tz=UTC) + timedelta(days=180)
     RENEW_NEEDED: datetime = datetime.now(tz=UTC) + timedelta(days=30)
 
-    # Key size for the RSA keys
-    RSA_KEY_SIZE: int = 4096
-
     _KEY_USAGE_CONSTRAINTS: dict[str, bool] = {
                 'digital_signature': True,
                 'content_commitment': True,
-                'key_encipherment': True,
+                'key_encipherment': False,
                 'data_encipherment': False,
-                'key_agreement': False,
+                'key_agreement': True,
                 'key_cert_sign': False,
                 'crl_sign': False,
                 'encipher_only': False,
@@ -109,8 +119,7 @@ class DataSecret(Secret):
         # the key to use for Fernet encryption/decryption
         self.shared_key: bytes | None = None
 
-        # The shared key encrypted with the private key of
-        # this secret
+        # The shared key encrypted for this secret's certificate
         self.protected_shared_key: bytes | None = None
 
         self.key_usage_constraints: dict[str, bool] = \
@@ -119,11 +128,9 @@ class DataSecret(Secret):
             DataSecret._EXTENDED_KEY_USAGE
         self.fernet = None
 
-    def generate_private_key(self) -> Ed25519PrivateKey:
-        _LOGGER.debug('Generating RSA private key for a data secret')
-        return rsa.generate_private_key(
-            public_exponent=65537, key_size=DataSecret.RSA_KEY_SIZE
-        )
+    def generate_private_key(self) -> ec.EllipticCurvePrivateKey:
+        _LOGGER.debug('Generating EC private key for a data secret')
+        return ec.generate_private_key(ec.SECP256R1())
 
     def encrypt(self, data: bytes, with_logging: bool = True) -> bytes:
         '''
@@ -237,14 +244,14 @@ class DataSecret(Secret):
 
         self.shared_key = Fernet.generate_key()
 
-        public_key: RSAPublicKey = target_secret.cert.public_key()
-        self.protected_shared_key = public_key.encrypt(
-            self.shared_key,
-            padding.OAEP(
-                mgf=padding.MGF1(algorithm=hashes.SHA256()),
-                algorithm=hashes.SHA256(),
-                label=None
+        public_key = target_secret.cert.public_key()
+        if not isinstance(public_key, ec.EllipticCurvePublicKey):
+            raise TypeError(
+                'Data secret certificates must use EC public keys'
             )
+
+        self.protected_shared_key = self._protect_shared_key(
+            public_key, self.shared_key
         )
 
         _LOGGER.debug('Initializing new Fernet instance')
@@ -264,18 +271,128 @@ class DataSecret(Secret):
         )
 
         self.protected_shared_key = protected_shared_key
-        self.shared_key = self.private_key.decrypt(
-            self.protected_shared_key,
-            padding.OAEP(
-                mgf=padding.MGF1(algorithm=hashes.SHA256()),
-                algorithm=hashes.SHA256(),
-                label=None
-            )
-        )
+        self.shared_key = self._unprotect_shared_key(protected_shared_key)
         _LOGGER.debug(
             'Initializing new Fernet instance from decrypted shared secret'
         )
         self.fernet = Fernet(self.shared_key)
+
+    @staticmethod
+    def _b64encode(data: bytes) -> str:
+        return base64.b64encode(data).decode('ascii')
+
+    @staticmethod
+    def _b64decode(envelope: dict[str, str], key: str) -> bytes:
+        value: str | None = envelope.get(key)
+        if not isinstance(value, str):
+            raise ValueError(f'Protected shared key is missing {key}')
+
+        try:
+            return base64.b64decode(value.encode('ascii'), validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ValueError(
+                f'Protected shared key has invalid {key}'
+            ) from exc
+
+    @staticmethod
+    def _derive_wrapping_key(
+        private_key: ec.EllipticCurvePrivateKey,
+        public_key: ec.EllipticCurvePublicKey,
+        salt: bytes,
+    ) -> bytes:
+        shared_secret: bytes = private_key.exchange(ec.ECDH(), public_key)
+        return HKDF(
+            algorithm=hashes.SHA256(),
+            length=_KEY_ENVELOPE_KEY_LENGTH,
+            salt=salt,
+            info=_KEY_ENVELOPE_INFO,
+        ).derive(shared_secret)
+
+    @staticmethod
+    def _protect_shared_key(
+        public_key: ec.EllipticCurvePublicKey, shared_key: bytes
+    ) -> bytes:
+        ephemeral_key: ec.EllipticCurvePrivateKey = ec.generate_private_key(
+            ec.SECP256R1()
+        )
+        salt: bytes = os.urandom(_KEY_ENVELOPE_SALT_LENGTH)
+        nonce: bytes = os.urandom(_KEY_ENVELOPE_NONCE_LENGTH)
+        wrapping_key: bytes = DataSecret._derive_wrapping_key(
+            ephemeral_key, public_key, salt
+        )
+        ciphertext: bytes = AESGCM(wrapping_key).encrypt(
+            nonce, shared_key, _KEY_ENVELOPE_MAGIC
+        )
+        ephemeral_public_key: bytes = ephemeral_key.public_key().public_bytes(
+            serialization.Encoding.X962,
+            serialization.PublicFormat.UncompressedPoint,
+        )
+        envelope: dict[str, str] = {
+            'algorithm': _KEY_ENVELOPE_ALGORITHM,
+            'curve': _KEY_ENVELOPE_CURVE,
+            'ephemeral_public_key': DataSecret._b64encode(
+                ephemeral_public_key
+            ),
+            'salt': DataSecret._b64encode(salt),
+            'nonce': DataSecret._b64encode(nonce),
+            'ciphertext': DataSecret._b64encode(ciphertext),
+        }
+        return _KEY_ENVELOPE_MAGIC + json.dumps(
+            envelope, separators=(',', ':'), sort_keys=True
+        ).encode('utf-8')
+
+    def _unprotect_shared_key(self, protected_shared_key: bytes) -> bytes:
+        if not isinstance(protected_shared_key, bytes):
+            raise ValueError('Protected shared key must be bytes')
+
+        if not protected_shared_key.startswith(_KEY_ENVELOPE_MAGIC):
+            raise ValueError('Unsupported protected shared key format')
+
+        if not isinstance(self.private_key, ec.EllipticCurvePrivateKey):
+            raise TypeError('Data secret private key must be an EC key')
+
+        payload: bytes = protected_shared_key[len(_KEY_ENVELOPE_MAGIC):]
+        try:
+            envelope = json.loads(payload.decode('utf-8'))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise ValueError('Protected shared key has invalid envelope') \
+                from exc
+
+        if not isinstance(envelope, dict):
+            raise ValueError('Protected shared key envelope must be an object')
+
+        if envelope.get('algorithm') != _KEY_ENVELOPE_ALGORITHM:
+            raise ValueError('Unsupported protected shared key algorithm')
+
+        if envelope.get('curve') != _KEY_ENVELOPE_CURVE:
+            raise ValueError('Unsupported protected shared key curve')
+
+        ephemeral_public_key: bytes = DataSecret._b64decode(
+            envelope, 'ephemeral_public_key'
+        )
+        salt: bytes = DataSecret._b64decode(envelope, 'salt')
+        nonce: bytes = DataSecret._b64decode(envelope, 'nonce')
+        ciphertext: bytes = DataSecret._b64decode(envelope, 'ciphertext')
+
+        if len(salt) != _KEY_ENVELOPE_SALT_LENGTH:
+            raise ValueError('Protected shared key has invalid salt length')
+
+        if len(nonce) != _KEY_ENVELOPE_NONCE_LENGTH:
+            raise ValueError('Protected shared key has invalid nonce length')
+
+        try:
+            public_key = ec.EllipticCurvePublicKey.from_encoded_point(
+                ec.SECP256R1(), ephemeral_public_key
+            )
+            wrapping_key: bytes = DataSecret._derive_wrapping_key(
+                self.private_key, public_key, salt
+            )
+            return AESGCM(wrapping_key).decrypt(
+                nonce, ciphertext, _KEY_ENVELOPE_MAGIC
+            )
+        except (InvalidTag, ValueError) as exc:
+            raise ValueError('Unable to decrypt protected shared key') \
+                from exc
 
     def sign_message(self, message: str, hash_algorithm: str = 'SHA256'
                      ) -> bytes:
@@ -306,12 +423,7 @@ class DataSecret(Secret):
         digest: bytes = DataSecret._get_digest(message, chosen_hash)
 
         signature: bytes = self.private_key.sign(
-            digest,
-            padding.PSS(
-                mgf=padding.MGF1(chosen_hash),
-                salt_length=padding.PSS.MAX_LENGTH
-            ),
-            utils.Prehashed(chosen_hash)
+            digest, ec.ECDSA(utils.Prehashed(chosen_hash))
         )
 
         return signature
@@ -349,11 +461,7 @@ class DataSecret(Secret):
         self.cert.public_key().verify(
             signature,
             digest,
-            padding.PSS(
-                mgf=padding.MGF1(hashes.SHA256()),
-                salt_length=padding.PSS.MAX_LENGTH
-            ),
-            utils.Prehashed(chosen_hash)
+            ec.ECDSA(utils.Prehashed(chosen_hash))
         )
 
     @staticmethod
@@ -365,9 +473,9 @@ class DataSecret(Secret):
         hasher = hashes.Hash(chosen_hash)
         message = copy(message)
         while message:
-            if len(message) > _RSA_SIGN_MAX_MESSAGE_LENGTH:
-                hasher.update(message[:_RSA_SIGN_MAX_MESSAGE_LENGTH])
-                message = message[_RSA_SIGN_MAX_MESSAGE_LENGTH:]
+            if len(message) > _SIGN_MAX_MESSAGE_LENGTH:
+                hasher.update(message[:_SIGN_MAX_MESSAGE_LENGTH])
+                message = message[_SIGN_MAX_MESSAGE_LENGTH:]
             else:
                 hasher.update(message)
                 message = None

--- a/byoda/secrets/member_data_secret.py
+++ b/byoda/secrets/member_data_secret.py
@@ -86,7 +86,7 @@ class MemberDataSecret(DataSecret):
     @override
     async def create(self, expire: int = 109500) -> None:
         '''
-        Creates an RSA private key and X.509 cert
+        Creates a private key and X.509 cert
 
         :param int expire: days after which the cert should expire
         :returns: (none)
@@ -106,7 +106,7 @@ class MemberDataSecret(DataSecret):
     async def create_csr(self, renew: bool = False
                          ) -> CertificateSigningRequest:
         '''
-        Creates an RSA private key and X.509 CSR
+        Creates a private key and X.509 CSR
 
         :param renew: should any existing private key be used to
         renew an existing certificate

--- a/byoda/secrets/network_data_secret.py
+++ b/byoda/secrets/network_data_secret.py
@@ -48,7 +48,7 @@ class NetworkDataSecret(DataSecret):
     @override
     async def create(self, expire: int = 1085) -> None:
         '''
-        Creates an RSA private key and X.509 cert
+        Creates a private key and X.509 cert
 
         :param int expire: days after which the cert should expire
         :returns: (none)
@@ -66,7 +66,7 @@ class NetworkDataSecret(DataSecret):
     async def create_csr(self, network: str = None, renew: bool = False
                          ) -> CertificateSigningRequest:
         '''
-        Creates an RSA private key and X.509 CSR
+        Creates a private key and X.509 CSR
 
         :param network: the name of the network
         :param renew: should any existing private key be used to

--- a/byoda/secrets/service_data_secret.py
+++ b/byoda/secrets/service_data_secret.py
@@ -54,7 +54,7 @@ class ServiceDataSecret(DataSecret):
     async def create_csr(self, service_id: int = None, renew: bool = False,
                          ) -> CertificateSigningRequest:
         '''
-        Creates an RSA private key and X.509 CSR
+        Creates a private key and X.509 CSR
 
         :param service_id: identifier for the service
         :param renew: should any existing private key be used to

--- a/podserver/dependencies/pod_api_request_auth.py
+++ b/podserver/dependencies/pod_api_request_auth.py
@@ -307,6 +307,24 @@ class PodApiRequestAuth(RequestAuth):
                 f'Authentication for service f{self.service_id}: '
                 f'{self.is_authenticated}'
             )
+        elif id_type == IdType.APP:
+            await super().authenticate(
+                self.tls_status, self.client_dn, self.issuing_ca_dn,
+                self.client_cert, self.authorization
+            )
+            if self.auth_source == AuthSource.CERT:
+                self.check_app_cert(service_id, network)
+            else:
+                raise HTTPException(
+                    status_code=401,
+                    detail='App authentication requires a TLS client cert'
+                )
+
+            self.is_authenticated = True
+            _LOGGER.debug(
+                f'Authentication for app {self.app_id}: '
+                f'{self.is_authenticated}'
+            )
         elif id_type == IdType.ANONYMOUS:
             self.is_authenticated = False
             self.id_type = IdType.ANONYMOUS

--- a/svcserver/dependencies/apprequest_auth.py
+++ b/svcserver/dependencies/apprequest_auth.py
@@ -71,9 +71,9 @@ class AppRequestAuthOptionalFast(RequestAuth):
         except ByodaMissingAuthInfo:
             return
 
-        if self.id_type != IdType.MEMBER:
+        if self.id_type != IdType.APP:
             _LOGGER.debug(
-                f'Authentication with {self.id_type} cert instead of an'
+                f'Authentication with {self.id_type} cert instead of an '
                 f'app cert'
             )
             raise HTTPException(status_code=403)

--- a/tests/unit/auth_test.py
+++ b/tests/unit/auth_test.py
@@ -13,6 +13,9 @@ import sys
 import shutil
 import unittest
 
+from types import SimpleNamespace
+from urllib.parse import quote
+from uuid import uuid4
 from logging import Logger
 
 from cryptography.hazmat.primitives.asymmetric.dsa import DSAPublicKey
@@ -28,23 +31,38 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.backends import default_backend
 from cryptography import x509
 
+from fastapi import HTTPException
+
 from byoda.requestauth.requestauth import RequestAuth
 
 from byoda.datamodel.account import Account
 from byoda.datamodel.member import Member
 from byoda.datamodel.member import Secret
+from byoda.secrets.networkrootca_secret import NetworkRootCaSecret
+from byoda.secrets.networkservicesca_secret import NetworkServicesCaSecret
+from byoda.secrets.serviceca_secret import ServiceCaSecret
+from byoda.secrets.service_secret import ServiceSecret
+from byoda.secrets.membersca_secret import MembersCaSecret
+from byoda.secrets.member_secret import MemberSecret
+from byoda.secrets.appsca_secret import AppsCaSecret
+from byoda.secrets.app_secret import AppSecret
 
 from byoda.servers.pod_server import PodServer
 
+from byoda.datatypes import CloudType
 from byoda.datatypes import IdType
+from byoda.datatypes import ServerType
 from byoda.datatypes import TlsStatus
 
 from byoda.requestauth.jwt import JWT
 
 from byoda.util.api_client.api_client import ApiClient
 from byoda.util.api_client.api_client import HttpMethod
+from byoda.util.paths import Paths
 
 from byoda.util.logger import Logger as ByodaLogger
+
+from byoda.storage.filestorage import FileStorage
 
 from byoda import config
 
@@ -59,6 +77,309 @@ from tests.lib.defines import ADDRESSBOOK_SERVICE_ID
 CONFIG_FILE = 'tests/collateral/config.yml'
 
 TEST_DIR = '/tmp/byoda-tests/auth'
+NETWORK = 'test.net'
+TARGET_SERVICE_ID = 2222
+ROGUE_SERVICE_ID = 1111
+
+
+def _escaped_cert(secret: Secret) -> str:
+    return quote(secret.cert_as_pem().decode('utf-8'), safe='')
+
+
+class TestMTlsCertChain(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        shutil.rmtree(TEST_DIR, ignore_errors=True)
+        os.makedirs(TEST_DIR, exist_ok=True)
+
+        storage = FileStorage(TEST_DIR, CloudType.LOCAL)
+        self.paths = Paths(
+            network=NETWORK, root_directory=TEST_DIR, account='pod',
+            storage_driver=storage,
+        )
+        self.network = SimpleNamespace(name=NETWORK, paths=self.paths)
+
+        self.root_ca = NetworkRootCaSecret(paths=self.paths)
+        await self.root_ca.create()
+
+        self.services_ca = NetworkServicesCaSecret(self.paths)
+        services_ca_csr = await self.services_ca.create_csr()
+        self.services_ca.from_signed_cert(
+            self.root_ca.sign_csr(services_ca_csr)
+        )
+
+        (
+            self.target_service_ca,
+            self.target_members_ca,
+            self.target_apps_ca,
+        ) = \
+            await self._create_service_branch(TARGET_SERVICE_ID)
+        (
+            self.rogue_service_ca,
+            self.rogue_members_ca,
+            self.rogue_apps_ca,
+        ) = \
+            await self._create_service_branch(ROGUE_SERVICE_ID)
+
+        local_member = await self._create_member_secret(
+            self.target_members_ca, TARGET_SERVICE_ID
+        )
+
+        service = SimpleNamespace(apps_ca=self.target_apps_ca)
+        membership = SimpleNamespace(
+            tls_secret=local_member,
+            service_id=TARGET_SERVICE_ID,
+            service=service,
+            service_ca_certchain=self.target_service_ca,
+        )
+        account = SimpleNamespace(
+            memberships={TARGET_SERVICE_ID: membership},
+        )
+        config.server = SimpleNamespace(
+            account=account,
+            network=SimpleNamespace(
+                name=NETWORK, paths=self.paths, root_ca=self.root_ca,
+            ),
+            server_type=ServerType.POD,
+        )
+
+    async def _create_service_branch(
+        self, service_id: int
+    ) -> tuple[ServiceCaSecret, MembersCaSecret, AppsCaSecret]:
+        service_ca = ServiceCaSecret(service_id, self.network)
+        service_ca_csr = await service_ca.create_csr()
+        service_ca.from_signed_cert(self.services_ca.sign_csr(service_ca_csr))
+
+        members_ca = MembersCaSecret(service_id, self.network)
+        members_ca_csr = await members_ca.create_csr()
+        members_ca.from_signed_cert(service_ca.sign_csr(members_ca_csr))
+
+        apps_ca = AppsCaSecret(service_id, self.network)
+        apps_ca_csr = await apps_ca.create_csr()
+        apps_ca.from_signed_cert(service_ca.sign_csr(apps_ca_csr))
+
+        return service_ca, members_ca, apps_ca
+
+    async def _create_member_secret(
+        self, members_ca: MembersCaSecret, service_id: int,
+        skip_ca_policy: bool = False,
+    ) -> MemberSecret:
+        member_secret = MemberSecret(
+            uuid4(), service_id, paths=self.paths, network_name=NETWORK
+        )
+        member_csr = await member_secret.create_csr()
+        if skip_ca_policy:
+            member_secret.from_signed_cert(
+                members_ca.sign_csr(member_csr, expire=365)
+            )
+        else:
+            member_secret.from_signed_cert(members_ca.sign_csr(member_csr))
+
+        return member_secret
+
+    async def _create_app_secret(
+        self, apps_ca: AppsCaSecret, service_id: int,
+        skip_ca_policy: bool = False,
+    ) -> AppSecret:
+        app_secret = AppSecret(uuid4(), service_id, self.network)
+        app_csr = await app_secret.create_csr(
+            f'app-{app_secret.app_id}.{NETWORK}'
+        )
+        if skip_ca_policy:
+            app_secret.from_signed_cert(
+                apps_ca.sign_csr(app_csr, expire=365)
+            )
+        else:
+            app_secret.from_signed_cert(apps_ca.sign_csr(app_csr))
+
+        return app_secret
+
+    async def _create_service_secret(
+        self, service_ca: ServiceCaSecret, service_id: int,
+        skip_ca_policy: bool = False,
+    ) -> ServiceSecret:
+        service_secret = ServiceSecret(service_id, self.network)
+        service_csr = await service_secret.create_csr()
+        if skip_ca_policy:
+            service_secret.from_signed_cert(
+                service_ca.sign_csr(service_csr, expire=2 * 365)
+            )
+        else:
+            service_secret.from_signed_cert(service_ca.sign_csr(service_csr))
+
+        return service_secret
+
+    async def test_rejects_member_cert_signed_by_rogue_service_ca(self) -> None:
+        rogue_member = await self._create_member_secret(
+            self.rogue_members_ca, TARGET_SERVICE_ID, skip_ca_policy=True
+        )
+        client_dn = f'CN={rogue_member.common_name}'
+        ca_dn = f'CN={self.rogue_members_ca.common_name}'
+
+        auth = RequestAuth('127.0.0.1', HttpMethod.GET)
+        await auth.authenticate(
+            TlsStatus.SUCCESS, client_dn, ca_dn,
+            _escaped_cert(rogue_member), None
+        )
+
+        with self.assertRaises(HTTPException) as exc:
+            auth.check_member_cert(TARGET_SERVICE_ID, config.server.network)
+        self.assertEqual(exc.exception.status_code, 403)
+
+    async def test_accepts_member_cert_signed_by_expected_members_ca(
+        self
+    ) -> None:
+        member = await self._create_member_secret(
+            self.target_members_ca, TARGET_SERVICE_ID
+        )
+        client_dn = f'CN={member.common_name}'
+        ca_dn = f'CN={self.target_members_ca.common_name}'
+
+        auth = RequestAuth('127.0.0.1', HttpMethod.GET)
+        await auth.authenticate(
+            TlsStatus.SUCCESS, client_dn, ca_dn,
+            _escaped_cert(member), None
+        )
+
+        auth.check_member_cert(TARGET_SERVICE_ID, config.server.network)
+
+    async def test_rejects_service_cert_signed_by_rogue_service_ca(
+        self
+    ) -> None:
+        rogue_service = await self._create_service_secret(
+            self.rogue_service_ca, TARGET_SERVICE_ID, skip_ca_policy=True
+        )
+        client_dn = f'CN={rogue_service.common_name}'
+        ca_dn = f'CN={self.rogue_service_ca.common_name}'
+
+        auth = RequestAuth('127.0.0.1', HttpMethod.GET)
+        await auth.authenticate(
+            TlsStatus.SUCCESS, client_dn, ca_dn,
+            _escaped_cert(rogue_service), None
+        )
+
+        with self.assertRaises(HTTPException) as exc:
+            auth.check_service_cert(config.server.network)
+        self.assertEqual(exc.exception.status_code, 403)
+
+    async def test_rejects_service_cert_signed_by_lookalike_service_ca(
+        self
+    ) -> None:
+        lookalike_service_ca = ServiceCaSecret(TARGET_SERVICE_ID, self.network)
+        lookalike_service_ca_csr = await lookalike_service_ca.create_csr()
+        lookalike_service_ca.from_signed_cert(
+            self.services_ca.sign_csr(
+                lookalike_service_ca_csr, expire=15 * 365
+            )
+        )
+        lookalike_service = await self._create_service_secret(
+            lookalike_service_ca, TARGET_SERVICE_ID
+        )
+        client_dn = f'CN={lookalike_service.common_name}'
+        ca_dn = f'CN={lookalike_service_ca.common_name}'
+
+        auth = RequestAuth('127.0.0.1', HttpMethod.GET)
+        await auth.authenticate(
+            TlsStatus.SUCCESS, client_dn, ca_dn,
+            _escaped_cert(lookalike_service), None
+        )
+
+        with self.assertRaises(HTTPException) as exc:
+            auth.check_service_cert(config.server.network)
+        self.assertEqual(exc.exception.status_code, 403)
+
+    async def test_accepts_service_cert_signed_by_expected_service_ca(
+        self
+    ) -> None:
+        service = await self._create_service_secret(
+            self.target_service_ca, TARGET_SERVICE_ID
+        )
+        client_dn = f'CN={service.common_name}'
+        ca_dn = f'CN={self.target_service_ca.common_name}'
+
+        auth = RequestAuth('127.0.0.1', HttpMethod.GET)
+        await auth.authenticate(
+            TlsStatus.SUCCESS, client_dn, ca_dn,
+            _escaped_cert(service), None
+        )
+
+        auth.check_service_cert(config.server.network)
+
+    async def test_rejects_app_cert_signed_by_rogue_service_ca(self) -> None:
+        rogue_app = await self._create_app_secret(
+            self.rogue_apps_ca, TARGET_SERVICE_ID, skip_ca_policy=True
+        )
+        client_dn = f'CN={rogue_app.common_name}'
+        ca_dn = f'CN={self.rogue_apps_ca.common_name}'
+
+        auth = RequestAuth('127.0.0.1', HttpMethod.GET)
+        await auth.authenticate(
+            TlsStatus.SUCCESS, client_dn, ca_dn,
+            _escaped_cert(rogue_app), None
+        )
+
+        with self.assertRaises(HTTPException) as exc:
+            auth.check_app_cert(TARGET_SERVICE_ID, config.server.network)
+        self.assertEqual(exc.exception.status_code, 403)
+
+    async def test_rejects_app_cert_signed_by_rogue_lookalike_apps_ca(
+        self
+    ) -> None:
+        rogue_apps_ca = AppsCaSecret(TARGET_SERVICE_ID, self.network)
+        rogue_apps_ca_csr = await rogue_apps_ca.create_csr()
+        rogue_apps_ca.from_signed_cert(
+            self.rogue_service_ca.sign_csr(rogue_apps_ca_csr, expire=5 * 365)
+        )
+        rogue_app = await self._create_app_secret(
+            rogue_apps_ca, TARGET_SERVICE_ID
+        )
+        client_dn = f'CN={rogue_app.common_name}'
+        ca_dn = f'CN={rogue_apps_ca.common_name}'
+
+        auth = RequestAuth('127.0.0.1', HttpMethod.GET)
+        await auth.authenticate(
+            TlsStatus.SUCCESS, client_dn, ca_dn,
+            _escaped_cert(rogue_app), None
+        )
+
+        with self.assertRaises(HTTPException) as exc:
+            auth.check_app_cert(TARGET_SERVICE_ID, config.server.network)
+        self.assertEqual(exc.exception.status_code, 403)
+
+    async def test_accepts_app_cert_signed_by_expected_apps_ca(self) -> None:
+        app = await self._create_app_secret(
+            self.target_apps_ca, TARGET_SERVICE_ID
+        )
+        client_dn = f'CN={app.common_name}'
+        ca_dn = f'CN={self.target_apps_ca.common_name}'
+
+        auth = RequestAuth('127.0.0.1', HttpMethod.GET)
+        await auth.authenticate(
+            TlsStatus.SUCCESS, client_dn, ca_dn,
+            _escaped_cert(app), None
+        )
+
+        auth.check_app_cert(TARGET_SERVICE_ID, config.server.network)
+
+    async def test_accepts_app_cert_with_apps_ca_from_local_cache(self) -> None:
+        membership = config.server.account.memberships[TARGET_SERVICE_ID]
+        membership.service.apps_ca = None
+        await self.target_apps_ca.save(
+            storage_driver=self.paths.storage_driver, overwrite=True
+        )
+
+        app = await self._create_app_secret(
+            self.target_apps_ca, TARGET_SERVICE_ID
+        )
+        client_dn = f'CN={app.common_name}'
+        ca_dn = f'CN={self.target_apps_ca.common_name}'
+
+        auth = RequestAuth('127.0.0.1', HttpMethod.GET)
+        await auth.authenticate(
+            TlsStatus.SUCCESS, client_dn, ca_dn,
+            _escaped_cert(app), None
+        )
+
+        auth.check_app_cert(TARGET_SERVICE_ID, config.server.network)
 
 
 class TestAccountManager(unittest.IsolatedAsyncioTestCase):

--- a/tests/unit/secret_test.py
+++ b/tests/unit/secret_test.py
@@ -19,7 +19,6 @@ import tempfile
 import unittest
 
 from uuid import UUID
-from copy import copy
 from types import SimpleNamespace
 from logging import Logger
 from random import randint
@@ -35,11 +34,9 @@ from httpx import RequestError
 from cryptography import x509
 from cryptography.fernet import InvalidToken
 from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.primitives.hashes import Hash
 from cryptography.x509.oid import NameOID
-from cryptography.hazmat.primitives.asymmetric import padding
-from cryptography.hazmat.primitives.asymmetric import utils
 from cryptography.hazmat.primitives import hashes
 
 from byoda.datamodel.network import Network
@@ -93,6 +90,7 @@ SERVICE_ID = 12345678
 SCHEMA_VERSION = 1
 SCHEMA_DIR: str = f'/network-{NETWORK}/services/service-{SERVICE_ID}'
 SCHEMA_FILE: str = SCHEMA_DIR + '/service-contract.json'
+RSA_KEY_SIZE = 4096
 
 
 def _selfsigned_secret(common_name: str) -> Secret:
@@ -138,7 +136,7 @@ class _ReviewableCaSecret(CaSecret):
         self.service_id = service_id
         self.accepted_csrs = accepted_csrs or {IdType.ACCOUNT: 30}
         self.private_key = rsa.generate_private_key(
-            public_exponent=65537, key_size=DataSecret.RSA_KEY_SIZE,
+            public_exponent=65537, key_size=RSA_KEY_SIZE,
         )
         self.common_name = f'ca.{network}'
         self.create_selfsigned_cert(ca=True)
@@ -163,7 +161,7 @@ def _csr(
     hash_algorithm=hashes.SHA256(),
 ) -> x509.CertificateSigningRequest:
     key = rsa.generate_private_key(
-        public_exponent=65537, key_size=DataSecret.RSA_KEY_SIZE,
+        public_exponent=65537, key_size=RSA_KEY_SIZE,
     )
     csr_builder = x509.CertificateSigningRequestBuilder().subject_name(
         x509.Name([
@@ -218,7 +216,7 @@ def _csr(
 
 def _email_san_csr(common_name: str) -> x509.CertificateSigningRequest:
     key = rsa.generate_private_key(
-        public_exponent=65537, key_size=DataSecret.RSA_KEY_SIZE,
+        public_exponent=65537, key_size=RSA_KEY_SIZE,
     )
     return x509.CertificateSigningRequestBuilder().subject_name(
         x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
@@ -248,7 +246,7 @@ class _TrackingSecret(Secret):
 class _FakeIssuingCa:
     def __init__(self) -> None:
         self.private_key = rsa.generate_private_key(
-            public_exponent=65537, key_size=DataSecret.RSA_KEY_SIZE,
+            public_exponent=65537, key_size=RSA_KEY_SIZE,
         )
         self.common_name = 'fake-ca.test.net'
         self.cert = self._create_ca_cert()
@@ -658,21 +656,23 @@ class TestSecretBase(unittest.IsolatedAsyncioTestCase):
 
 
 class TestDataSecretBase(unittest.IsolatedAsyncioTestCase):
-    async def test_generates_rsa_key_and_data_secret_csr_extensions(
+    async def test_generates_ec_key_and_data_secret_csr_extensions(
         self
     ) -> None:
         secret = DataSecret()
 
         csr = await secret.create_csr('data.test.net')
 
-        self.assertEqual(secret.private_key.key_size, DataSecret.RSA_KEY_SIZE)
+        self.assertIsInstance(secret.private_key, ec.EllipticCurvePrivateKey)
+        self.assertIsInstance(secret.private_key.curve, ec.SECP256R1)
 
         key_usage = csr.extensions.get_extension_for_class(
             x509.KeyUsage
         ).value
         self.assertTrue(key_usage.digital_signature)
         self.assertTrue(key_usage.content_commitment)
-        self.assertTrue(key_usage.key_encipherment)
+        self.assertFalse(key_usage.key_encipherment)
+        self.assertTrue(key_usage.key_agreement)
         self.assertFalse(key_usage.key_cert_sign)
 
         extended_key_usage = csr.extensions.get_extension_for_class(
@@ -717,6 +717,22 @@ class TestDataSecretBase(unittest.IsolatedAsyncioTestCase):
 
         with self.assertRaises(ValueError):
             wrong_target.load_shared_key(source.protected_shared_key)
+
+    def test_load_shared_key_rejects_unsupported_key_format(self) -> None:
+        secret = _selfsigned_data_secret()
+
+        with self.assertRaises(ValueError):
+            secret.load_shared_key(b'old-rsa-oaep-ciphertext')
+
+    def test_create_shared_key_uses_ec_envelope_format(self) -> None:
+        source = _selfsigned_data_secret('source.test.net')
+        target = _selfsigned_data_secret('target.test.net')
+        source.create_shared_key(target)
+
+        self.assertTrue(
+            source.protected_shared_key.startswith(b'BYODA-DATA-KEY-v1\n')
+        )
+        self.assertNotIn(source.shared_key, source.protected_shared_key)
 
     def test_create_shared_key_replaces_existing_key(self) -> None:
         secret = _selfsigned_data_secret()
@@ -1459,7 +1475,7 @@ class TestCaSecretBase(unittest.IsolatedAsyncioTestCase):
             ca.sign_csr(csr, expire=1)
 
         ca.private_key = rsa.generate_private_key(
-            public_exponent=65537, key_size=DataSecret.RSA_KEY_SIZE,
+            public_exponent=65537, key_size=RSA_KEY_SIZE,
         )
         with self.assertRaises(ValueError):
             ca.sign_csr(csr, expire='tomorrow')
@@ -1649,7 +1665,7 @@ class TestAccountManager(unittest.IsolatedAsyncioTestCase):
             'root-ca.pem', 'root-ca.key', storage
         )
         root_ca.private_key = rsa.generate_private_key(
-            public_exponent=65537, key_size=DataSecret.RSA_KEY_SIZE,
+            public_exponent=65537, key_size=RSA_KEY_SIZE,
         )
         root_ca.common_name = 'test-root-ca'
         root_ca.create_selfsigned_cert(ca=True)
@@ -1691,7 +1707,7 @@ class TestAccountManager(unittest.IsolatedAsyncioTestCase):
             'root-ca.pem', 'root-ca.key', storage
         )
         root_ca.private_key = rsa.generate_private_key(
-            public_exponent=65537, key_size=DataSecret.RSA_KEY_SIZE,
+            public_exponent=65537, key_size=RSA_KEY_SIZE,
         )
         root_ca.common_name = 'test-root-ca'
         root_ca.create_selfsigned_cert(ca=True)
@@ -2010,98 +2026,19 @@ class TestAccountManager(unittest.IsolatedAsyncioTestCase):
             public_bucket='byoda', root_dir=TEST_DIR
         )
 
-        key: rsa.RSAPrivateKey = rsa.generate_private_key(
-           public_exponent=65537,
-           key_size=4096,
-        )
-
-        subject: x509.Name
-        issuer: x509.Name
-        subject = issuer = x509.Name(
-            [
-                x509.NameAttribute(NameOID.COUNTRY_NAME, u"US"),
-                x509.NameAttribute(
-                    NameOID.STATE_OR_PROVINCE_NAME, u"California"
-                ),
-                x509.NameAttribute(NameOID.LOCALITY_NAME, u"Los Gatos"),
-                x509.NameAttribute(NameOID.ORGANIZATION_NAME, u"byoda"),
-                x509.NameAttribute(NameOID.COMMON_NAME, u"byoda.org"),
-            ]
-        )
-
-        cert: x509.Certificate = x509.CertificateBuilder().subject_name(
-            subject
-        ).issuer_name(
-            issuer
-        ).public_key(
-            key.public_key()
-        ).serial_number(
-            x509.random_serial_number()
-        ).not_valid_before(
-            datetime.now(tz=UTC)
-        ).not_valid_after(
-            datetime.now(tz=UTC) + timedelta(days=1)
-        ).add_extension(
-            x509.SubjectAlternativeName([x509.DNSName(u"localhost")]),
-            critical=False,
-        ).sign(key, hashes.SHA256())
-
-        _RSA_SIGN_MAX_MESSAGE_LENGTH = 1024
-        message: bytes = 'ik ben toch niet gek!'.encode('utf-8')
-        chosen_hash = hashes.SHA256()
-        hasher: Hash = hashes.Hash(chosen_hash)
-        message = copy(message)
-        while message:
-            if len(message) > _RSA_SIGN_MAX_MESSAGE_LENGTH:
-                hasher.update(message[:_RSA_SIGN_MAX_MESSAGE_LENGTH])
-                message = message[_RSA_SIGN_MAX_MESSAGE_LENGTH:]
-            else:
-                hasher.update(message)
-                message = None
-        digest: bytes = hasher.finalize()
-        signature: bytes = key.sign(
-            digest,
-            padding.PSS(
-                mgf=padding.MGF1(chosen_hash),
-                salt_length=padding.PSS.MAX_LENGTH
-            ),
-            utils.Prehashed(chosen_hash)
-            )
-
-        cert.public_key().verify(
-            signature,
-            digest,
-            padding.PSS(
-                mgf=padding.MGF1(hashes.SHA256()),
-                salt_length=padding.PSS.MAX_LENGTH
-            ),
-            utils.Prehashed(chosen_hash)
-        )
-
         account = Account(get_test_uuid(), network)
         message = 'ik ben toch niet gek!'
 
         member_data_secret = MemberDataSecret(
             get_test_uuid(), ADDRESSBOOK_SERVICE_ID, account
         )
+        member_data_secret.private_key = \
+            member_data_secret.generate_private_key()
+        member_data_secret.common_name = MemberDataSecret.create_common_name(
+            member_data_secret.member_id, ADDRESSBOOK_SERVICE_ID, network
+        )
+        member_data_secret.create_selfsigned_cert()
 
-        member_data_secret.cert_file = 'azure-pod-member-data-cert.pem'
-        member_data_secret.private_key_file = 'azure-pod-member-data.key'
-        shutil.copy(
-            f'tests/collateral/local/{member_data_secret.cert_file}',
-            TEST_DIR
-        )
-        shutil.copy(
-            f'tests/collateral/local/{member_data_secret.private_key_file}',
-            TEST_DIR
-        )
-        filename: str = 'tests/collateral/local/azure-pod-private-key-password'
-        with open(filename) as file_desc:
-            private_key_password: str = file_desc.read().strip()
-
-        await member_data_secret.load(
-            with_private_key=True, password=private_key_password
-        )
         signature = member_data_secret.sign_message(message)
         member_data_secret.verify_message_signature(message, signature)
 


### PR DESCRIPTION
- Replace RSA and RSA-OAEP with Ecliptic Curve cryptography for data secrets
  - This change is NOT backwards-compatible. The current byoda.net network will be replaced with a new one and pods will need to re-register.
- Use cryptographic validation of cert-chains in the byoda pod during m-TLS authentication 